### PR TITLE
Selecionando tipo de dado no mapa interativo

### DIFF
--- a/app.R
+++ b/app.R
@@ -183,7 +183,7 @@ ui <- page_navbar(
         )
       )
       
-
+      
     )
   ),
   
@@ -749,7 +749,7 @@ server <- function(input, output, session) {
     cat("FIM DO RESUMO\n")
   }
   
-
+  
   
   # Renderização do sumário do modelo com ajuste para o GWR Multiscale
   output$summary_output_modelos <- renderPrint({

--- a/rsconnect/shinyapps.io/longevmap/LongevMap.dcf
+++ b/rsconnect/shinyapps.io/longevmap/LongevMap.dcf
@@ -1,0 +1,12 @@
+name: LongevMap
+title: LongevMap
+username: longevmap
+account: longevmap
+server: shinyapps.io
+hostUrl: https://api.shinyapps.io/v1
+appId: 13082218
+bundleId: 9250929
+url: https://longevmap.shinyapps.io/LongevMap/
+version: 1
+asMultiple: FALSE
+asStatic: FALSE


### PR DESCRIPTION
Basicamente mudamos o primeiro painel onde está o Mapa Interativo para que o mapa só seja inicializado após o usuário selecionar o tipo de banco de dados que deveremos utilizar (Brutos ou Per Capita).